### PR TITLE
bugfix for broken quick export

### DIFF
--- a/lib/xls_export.rb
+++ b/lib/xls_export.rb
@@ -58,7 +58,7 @@ module Redmine
 		def issues_to_xls2(issues, project, query, options = {}, sort_parent = false)
 	
 			Spreadsheet.client_encoding = 'UTF-8'
-			
+			options[:date_format] ||= 'dd.mm.yyyy'
 			options.default=false
 			show_relations = options[:relations]
 			show_watchers = options[:watchers] 


### PR DESCRIPTION
Hi!

I had the spreadsheet gem throwing a "TypeError (can't dup FalseClass)" when trying the quick export feature. Turns out the cause was the default date format being set to 'false' by default.

Cheers,
Jens
