### PR TITLE
Assorted fixes: Relative URL Root, Rails3 before_filter, Date format in Journals export

### DIFF
--- a/app/controllers/xls_export_controller.rb
+++ b/app/controllers/xls_export_controller.rb
@@ -143,7 +143,7 @@ protected
             rescue
               nil
             end
-            zip_stream.put_next_entry("#{file ? "#{ATTACHMENTS_FOLDER}/" : "#{NOT_FOUND_ATTACHMENTS_FOLDER}/"}%05i/#{create_zip_filename(attach)}" % [issue.id],nil,nil,Zip::ZipEntry::DEFLATED,Zlib::BEST_COMPRESSION)
+            zip_stream.put_next_entry("#{file ? "#{ATTACHMENTS_FOLDER}/" : "#{NOT_FOUND_ATTACHMENTS_FOLDER}/"}%d/#{create_zip_filename(attach)}" % [issue.id],nil,nil,Zip::ZipEntry::DEFLATED,Zlib::BEST_COMPRESSION)
             unless file
               file=StringIO.new('')
               file.write("\n")
@@ -155,7 +155,7 @@ protected
         if @settings['separate_journals'] == '1'
           journal_xls=journal_details_to_xls(issue, @settings)
           if journal_xls
-            zip_stream.put_next_entry("#{JOURNALS_FOLDER}/%05i_journal_details.xls" % [issue.id],nil,nil,Zip::ZipEntry::DEFLATED,Zlib::BEST_COMPRESSION)
+            zip_stream.put_next_entry("#{JOURNALS_FOLDER}/%d_journal_details.xls" % [issue.id],nil,nil,Zip::ZipEntry::DEFLATED,Zlib::BEST_COMPRESSION)
             zip_stream.write(journal_xls)
           end
         end

--- a/app/controllers/xls_export_controller.rb
+++ b/app/controllers/xls_export_controller.rb
@@ -26,7 +26,11 @@ class XlsExportController < ApplicationController
   helper :custom_fields
   include CustomFieldsHelper
 
-  before_action :find_optional_project_xls
+  if respond_to? :before_action
+    before_action :find_optional_project_xls
+  else
+    before_filter :find_optional_project_xls
+  end
 
   def index
     @issues_export_offset=params[:issues_export_offset].to_i || 0

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -48,6 +48,7 @@ bg:
   default_start_date_format: "dd.mm.yyyy"
   default_due_date_format: "dd.mm.yyyy"
 
+  plugin_xlse_field_issue_id: "Issue ID"
   plugin_xlse_field_issue_created_on: "Issue created"
   plugin_xlse_field_status_from: "Status from"
   plugin_xlse_field_status_to: "Status to"

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -48,6 +48,7 @@ cs:
   default_start_date_format: "dd.mm.yyyy"
   default_due_date_format: "dd.mm.yyyy"
 
+  plugin_xlse_field_issue_id: "Issue ID"
   plugin_xlse_field_issue_created_on: Vytvořeno
   plugin_xlse_field_status_from: Původní stav
   plugin_xlse_field_status_to: Nový stav

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -48,6 +48,7 @@ de:
   default_start_date_format: "dd.mm.yyyy"
   default_due_date_format: "dd.mm.yyyy"
 
+  plugin_xlse_field_issue_id: "Issue ID"
   plugin_xlse_field_issue_created_on: "Issue created"
   plugin_xlse_field_status_from: "Status from"
   plugin_xlse_field_status_to: "Status to"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,7 @@ en:
   default_due_date_format: "dd.mm.yyyy"
   default_closed_date_format: "dd.mm.yyyy hh:mm:ss"
 
+  plugin_xlse_field_issue_id: "Issue ID"
   plugin_xlse_field_issue_created_on: "Issue created"
   plugin_xlse_field_status_from: "Status from"
   plugin_xlse_field_status_to: "Status to"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -31,6 +31,7 @@ es:
   default_start_date_format: "dd.mm.yyyy"
   default_due_date_format: "dd.mm.yyyy"
 
+  plugin_xlse_field_issue_id: "Issue ID"
   plugin_xlse_field_issue_created_on: "Issue created"
   plugin_xlse_field_status_from: "Status from"
   plugin_xlse_field_status_to: "Status to"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -45,6 +45,7 @@ it:
   default_start_date_format: "dd.mm.yyyy"
   default_due_date_format: "dd.mm.yyyy"
 
+  plugin_xlse_field_issue_id: "Issue ID"
   plugin_xlse_field_issue_created_on: "Issue created"
   plugin_xlse_field_status_from: "Status from"
   plugin_xlse_field_status_to: "Status to"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -50,6 +50,7 @@ ja:
   default_due_date_format: "yyyy/mm/dd"
   default_closed_date_format: "yyyy/mm/dd hh:mm:ss"
 
+  plugin_xlse_field_issue_id: "Issue ID"
   plugin_xlse_field_issue_created_on: "チケットの作成日"
   plugin_xlse_field_status_from: "変更前のステータス"
   plugin_xlse_field_status_to: "変更後のステータス"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -43,6 +43,7 @@ ko:
   default_start_date_format: "dd.mm.yyyy"
   default_due_date_format: "dd.mm.yyyy"
 
+  plugin_xlse_field_issue_id: "Issue ID"
   plugin_xlse_field_issue_created_on: "Issue created"
   plugin_xlse_field_status_from: "Status from"
   plugin_xlse_field_status_to: "Status to"

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -38,6 +38,7 @@ pl:
   default_start_date_format: "dd.mm.yyyy"
   default_due_date_format: "dd.mm.yyyy"
 
+  plugin_xlse_field_issue_id: "Issue ID"
   plugin_xlse_field_issue_created_on: "Issue created"
   plugin_xlse_field_status_from: "Status from"
   plugin_xlse_field_status_to: "Status to"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -36,6 +36,7 @@ pt-BR:
   default_start_date_format: "dd.mm.yyyy"
   default_due_date_format: "dd.mm.yyyy"
 
+  plugin_xlse_field_issue_id: "Issue ID"
   plugin_xlse_field_issue_created_on: "Issue created"
   plugin_xlse_field_status_from: "Status from"
   plugin_xlse_field_status_to: "Status to"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -48,6 +48,7 @@ ru:
   default_start_date_format: "дд.мм.гггг"
   default_due_date_format: "дд.мм.гггг"
 
+  plugin_xlse_field_issue_id: "Issue ID"
   plugin_xlse_field_issue_created_on: "Задача создана"
   plugin_xlse_field_status_from: "Статус был"
   plugin_xlse_field_status_to: "Статус стал"

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -38,6 +38,7 @@ tr:
   label_plugin_xlse_export_format_detailed: "Detaylı"
   label_plugin_xlse_export_format_detailed_tooltip: "Dışa aktarmadan önce seçenekleri ayarla"
 
+  plugin_xlse_field_issue_id: "Issue ID"
   plugin_xlse_field_issue_created_on: "Issue created"
   plugin_xlse_field_status_from: "Status from"
   plugin_xlse_field_status_to: "Status to"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -48,6 +48,7 @@ vi:
   default_start_date_format: "dd.mm.yyyy"
   default_due_date_format: "dd.mm.yyyy"
 
+  plugin_xlse_field_issue_id: "Issue ID"
   plugin_xlse_field_issue_created_on: "Tác vụ được tạo"
   plugin_xlse_field_status_from: "Trạng thái bắt đầu"
   plugin_xlse_field_status_to: "Trạng thái kết thúc"

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -35,6 +35,7 @@ zh-TW:
   default_start_date_format: "dd.mm.yyyy"
   default_due_date_format: "dd.mm.yyyy"
 
+  plugin_xlse_field_issue_id: "Issue ID"
   plugin_xlse_field_issue_created_on: "Issue created"
   plugin_xlse_field_status_from: "Status from"
   plugin_xlse_field_status_to: "Status to"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -47,6 +47,7 @@ zh:
   default_start_date_format: "dd.mm.yyyy"
   default_due_date_format: "dd.mm.yyyy"
 
+  plugin_xlse_field_issue_id: "Issue ID"
   plugin_xlse_field_issue_created_on: "Issue created"
   plugin_xlse_field_status_from: "Status from"
   plugin_xlse_field_status_to: "Status to"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,8 @@
 if Rails::VERSION::MAJOR >= 3
-  RedmineApp::Application.routes.draw do
-    match 'issues_xls_export', :to => 'xls_export#index', :via => [:get, :post]
-    get 'issues_xls_export_current', :to => 'xls_export#export_current'
-    match 'projects/:project_id/issues_xls_export', :to => 'xls_export#index', :via => [:get, :post]
-    get 'projects/:project_id/issues_xls_export_current', :to => 'xls_export#export_current'
-  end
+  match 'issues_xls_export', :to => 'xls_export#index', :via => [:get, :post]
+  get 'issues_xls_export_current', :to => 'xls_export#export_current'
+  match 'projects/:project_id/issues_xls_export', :to => 'xls_export#index', :via => [:get, :post]
+  get 'projects/:project_id/issues_xls_export_current', :to => 'xls_export#export_current'
 else
   ActionController::Routing::Routes.draw do |map|
     map.with_options :controller => 'xls_export' do |issues_routes|

--- a/lib/xls_export.rb
+++ b/lib/xls_export.rb
@@ -403,11 +403,12 @@ module Redmine
 
         columns_width = []
         sheet1.row(0).replace []
-        ['#',l(:field_updated_on),l(:field_user),l(:label_details),l(:field_notes)].each do |c|
+        [l(:plugin_xlse_field_issue_id), '#', l(:field_updated_on),l(:field_user),l(:label_details),l(:field_notes)].each do |c|
           sheet1.row(0) << c
           columns_width << (get_value_width(c)*1.1)
         end
         sheet1.column(0).default_format = Spreadsheet::Format.new(:number_format => "0")
+        sheet1.column(1).default_format = Spreadsheet::Format.new(:number_format => "0")
 
         idx=0
         issue_updates.each do |journal|
@@ -423,7 +424,7 @@ module Redmine
             details = strip_html(details, options)
             notes = strip_html(journal.notes? ? journal.notes.to_s : '', options)
 
-            [idx+1,localtime(journal.created_on),journal.user.name,details,notes].each_with_index do |e,e_idx|
+            [issue.id,idx+1,localtime(journal.created_on),journal.user.name,details,notes].each_with_index do |e,e_idx|
               lf_pos = get_value_width(e)
               columns_width[e_idx] = lf_pos unless columns_width[e_idx] >= lf_pos
               row << e
@@ -578,7 +579,7 @@ module Redmine
       def add_columns_header_for_status_histories(sheet)
         columns_width = []
         sheet.row(0).replace []
-        ['#', l(:field_project), l(:plugin_xlse_field_issue_created_on),  l(:field_updated_on),
+        ['#', l(:field_project), l(:plugin_xlse_field_issue_created_on), l(:field_updated_on),
          l(:plugin_xlse_field_status_from), l(:plugin_xlse_field_status_to)].each do |c|
           sheet.row(0) << c
           columns_width << (get_value_width(c) * 1.1)

--- a/lib/xls_export.rb
+++ b/lib/xls_export.rb
@@ -410,6 +410,9 @@ module Redmine
         sheet1.column(0).default_format = Spreadsheet::Format.new(:number_format => "0")
         sheet1.column(1).default_format = Spreadsheet::Format.new(:number_format => "0")
 
+        date_formats = init_date_formats(options);
+        sheet1.column(2).default_format = Spreadsheet::Format.new(:number_format => date_formats[:updated_on])
+
         idx=0
         issue_updates.each do |journal|
           if !journal.private_notes? or User.current.allowed_to?(:view_private_notes, journal.project)

--- a/lib/xls_export.rb
+++ b/lib/xls_export.rb
@@ -399,7 +399,7 @@ module Redmine
 
         Spreadsheet.client_encoding = 'UTF-8'
         book = Spreadsheet::Workbook.new
-        sheet1 = book.create_worksheet(:name => "%05i - Journal" % [issue.id])
+        sheet1 = book.create_worksheet(:name => "%d - Journal" % [issue.id])
 
         columns_width = []
         sheet1.row(0).replace []


### PR DESCRIPTION
Hello,

I recently added this plugin to a Redmine 2.4 installation, and it works well. Below some assorted fixes:

* Honor RAILS_RELATIVE_URL_ROOT (c9a6aef)
* Use before_filter on R3/R4 and before_action on newer rails (03af38b)
* Correct date format in journals export (b65e06b)

And one addition:

* Add issue ID in journals export (7344a84)

I hope that it is OK for you to have a single pull request rather than four :-). I couldn't run tests on my 2.4 instance, but I'll fix any breakage highlighted by travis.

Cheers,