### PR TITLE
Fixes invalid assertion to visit page.

### DIFF
--- a/test/integration/detailed_page_test.rb
+++ b/test/integration/detailed_page_test.rb
@@ -19,12 +19,12 @@ class DetailedPageTest < Redmine::IntegrationTest
   def setup
     login_with_user
     visit '/projects/ecookbook/issues_xls_export'
-    assert_not_nil page
+    assert_visit
   end
 
   def test_detailed_link_is_in_issues_page
     visit '/projects/ecookbook/issues'
-    assert_not_nil page
+    assert_visit
     assert has_link?('Detailed')
   end
 
@@ -34,7 +34,7 @@ class DetailedPageTest < Redmine::IntegrationTest
 
   def test_to_back_issues_page
     visit '/projects/ecookbook/issues'
-    assert_not_nil page
+    assert_visit
     click_link 'Tracker'
     assert has_selector?('th a.sort', :text => 'Tracker')
 

--- a/test/integration/quick_export_test.rb
+++ b/test/integration/quick_export_test.rb
@@ -35,7 +35,7 @@ class QuickExportTest < Redmine::IntegrationTest
 
   def assert_quick_export(filename, ext, generated = true)
     visit '/projects/ecookbook/issues'
-    assert_not_nil page
+    assert_visit
 
     click_link 'Quick'
     assert_to_export filename, ext, generated
@@ -50,7 +50,7 @@ class QuickExportTest < Redmine::IntegrationTest
 
   def test_quick_link_is_in_issues_page
     visit '/projects/ecookbook/issues'
-    assert_not_nil page
+    assert_visit
     assert has_link?('Quick')
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -52,12 +52,12 @@ class ActionDispatch::IntegrationTest
 
   def show_configure_page
     visit '/settings/plugin/redmine_xls_export'
-    assert_not_nil page
+    assert_visit
   end
 
   def show_detailed_page
     visit '/projects/ecookbook/issues_xls_export'
-    assert_not_nil page
+    assert_visit
   end
 
   def save_exported_xls(name)
@@ -99,6 +99,10 @@ class ActionDispatch::IntegrationTest
     fill_in 'settings_issues_limit', :with => '0'
     fill_in 'issues_export_offset', :with => '0'
     fill_in 'settings_export_name', :with => 'issues_export'
+  end
+
+  def assert_visit
+    assert has_selector?("div#content")
   end
 end
 


### PR DESCRIPTION
**assert_not_nil page** through rails error page.
This PR fixes it which check also to exist div#content.

But this plugin has no failure test cases with this problem.
See: https://github.com/two-pack/redmine_xlsx_format_issue_exporter/pull/89