### PR TITLE
Changes CI environment for chaning pull rate limits by DockerHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         redmine:
-          - v3.4
           - v4.0
           - v4.1
           - trunk
@@ -20,11 +19,6 @@ jobs:
           - v2.4
           - v2.5
           - v2.6
-        exclude:
-          - redmine: v3.4
-            ruby: v2.5
-          - redmine: v3.4
-            ruby: v2.6
 
     steps:
       - name: Redmine plugin test


### PR DESCRIPTION
DockerHub changes pull rate limits for free users.
https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/

I remove Redmine 3.x from CI environment.